### PR TITLE
Fix Mannequins

### DIFF
--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -13,8 +13,8 @@
 	GLOB.human_mob_list -= src
 	GLOB.living_mob_list -= src
 	GLOB.player_list -= src
-	sanity = null //Sanity datum onLife() proc is its own set of timers independant from /mob/proc/Life(), making it Null was the simpliest way to stop it from processing
-	delete_inventory()
+	qdel(sanity) //Sanity datum onLife() proc is its own set of timers independant from /mob/proc/Life(), this removes references that might try to ping it
+	sanity = null
 
 /mob/living/carbon/human/dummy/mannequin/fully_replace_character_name(var/oldname, var/newname)
 	..(newname = "[newname] (mannequin)")

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -11,10 +11,16 @@
 /mob/living/carbon/human/dummy/mannequin/Initialize()
 	. = ..()
 	GLOB.human_mob_list -= src
+	GLOB.living_mob_list -= src
+	GLOB.player_list -= src
+	sanity = null //Sanity datum onLife() proc is its own set of timers independant from /mob/proc/Life(), making it Null was the simpliest way to stop it from processing
 	delete_inventory()
 
 /mob/living/carbon/human/dummy/mannequin/fully_replace_character_name(var/oldname, var/newname)
 	..(newname = "[newname] (mannequin)")
+
+/mob/living/carbon/human/dummy/mannequin/Life()		//Disables mannequin from doing more than processing this one Life(), stops organ processing
+	return
 
 /mob/living/carbon/human/skeleton
 	icon_state = "skeleton"

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -15,6 +15,7 @@
 	GLOB.player_list -= src
 	qdel(sanity) //Sanity datum onLife() proc is its own set of timers independant from /mob/proc/Life(), this removes references that might try to ping it
 	sanity = null
+	delete_inventory()
 
 /mob/living/carbon/human/dummy/mannequin/fully_replace_character_name(var/oldname, var/newname)
 	..(newname = "[newname] (mannequin)")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Mannequins are full fledged mobs that processed damage, life ticks, and sanity. They suffered breakdowns. They were impacting server performance. Basically anytime a player opened their character sheet, it would make a mannequin. Sometimes, multiple mannequins depending on how many character sheets they opened. This reduces their impact to a fraction of a fraction of their previous impact.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Optimization good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
[https://puu.sh/Kq2I3/ca50a69844.webm](url) Testing video, as it was too long.
![dreamseeker_ftCI0RJqxf](https://github.com/user-attachments/assets/97caaec1-0623-4c42-a0a4-9fe983c2f04d)

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
fix: Mannequins no longer process Life() or sanity
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
