### PR TITLE
#8561 Port (Make it harder to decapitate people with rods and ammo boxes)

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -15,6 +15,7 @@
 	max_amount = 60
 	attack_verb = list("hit", "bludgeoned", "whacked")
 	price_tag = 1
+	automerge = TRUE
 
 /obj/item/stack/rods/random
 	rand_min = 2
@@ -31,6 +32,7 @@
 	charge_costs = list(500)
 	stacktype = /obj/item/stack/rods
 	spawn_tags = null
+	automerge = FALSE
 
 /obj/item/stack/rods/attackby(obj/item/I, mob/living/user)
 	..()

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -26,14 +26,15 @@
 	var/consumable = TRUE	// Will the stack disappear entirely once the amount is used up?
 	var/splittable = TRUE	// Is the stack capable of being splitted?
 	var/novariants = TRUE //Determines whether the item should update it's sprites based on amount.
+	var/automerge = FALSE // Automatically merge with stacks on the same tile?
 
 	//If either of these two are set to nonzero values, the stack will have randomised quantity on spawn
 	//Used for the /random subtypes of material stacks. any stack works
 	var/rand_min = 0
 	var/rand_max = 0
-
-
-
+	//Damage dealt to something when falling on it, per amount in the stack.
+	//IE, if this is 0.2 a stack of 120 will deal 24 base damage when falling on a mob
+	var/fall_damage_per_amount = 0.2
 
 /obj/item/stack/New(var/loc, var/amount=null)
 	.=..()
@@ -41,7 +42,7 @@
 		src.amount = amount
 
 /obj/item/stack/Initialize()
-	.=..()
+	. = ..()
 	if (!stacktype)
 		stacktype = type
 
@@ -49,6 +50,14 @@
 		amount = rand(rand_min, rand_max)
 		amount = round(amount, 1) //Just in case
 	update_icon()
+	if(automerge)
+		return INITIALIZE_HINT_LATELOAD
+
+//do this a little later because trying to merge with uninitialized stacks is an easy way to cause runtimes
+/obj/item/stack/LateInitialize()
+	. = ..()
+	if(automerge)
+		merge_loc_stacks()
 
 /obj/item/stack/update_icon()
 	if(novariants)
@@ -378,6 +387,9 @@
 	else
 		return ..()
 
+/obj/item/stack/get_fall_damage()
+	return amount * fall_damage_per_amount
+
 //Verb to split stacks
 /obj/item/stack/verb/split_verb()
 	set src in view(1)
@@ -412,6 +424,16 @@
 
 /obj/item/stack/get_item_cost(export)
 	return amount * ..()
+
+/obj/item/stack/Crossed(O)
+	. = ..()
+	if(automerge && (O != src) && istype(O, /obj/item/stack))
+		transfer_to(O)
+
+/obj/item/stack/proc/merge_loc_stacks()
+	for(var/obj/item/stack/material/loc_stack in loc)
+		if(loc_stack != src)
+			transfer_to(loc_stack)
 
 /*
  * Recipe datum

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -8,6 +8,7 @@
 	throw_range = 3
 	max_amount = 120
 	bad_type = /obj/item/stack/material
+	automerge = TRUE
 
 	var/default_type = MATERIAL_STEEL
 	var/material/material
@@ -89,7 +90,6 @@
 /obj/item/stack/material/add(extra)
 	..()
 	update_strings()
-
 
 /obj/item/stack/material/iron
 	name = "iron"
@@ -271,6 +271,7 @@
 	apply_colour = 1
 	price_tag = 50
 	novariants = FALSE
+	fall_damage_per_amount = 0.5
 
 /obj/item/stack/material/osmium/full
 	amount = 120

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -11,10 +11,17 @@
 /mob/living/carbon/human/dummy/mannequin/Initialize()
 	. = ..()
 	GLOB.human_mob_list -= src
+	GLOB.living_mob_list -= src
+	GLOB.player_list -= src
+	qdel(sanity) //Sanity datum onLife() proc is its own set of timers independant from /mob/proc/Life(), this removes references that might try to ping it
+	sanity = null
 	delete_inventory()
 
 /mob/living/carbon/human/dummy/mannequin/fully_replace_character_name(var/oldname, var/newname)
 	..(newname = "[newname] (mannequin)")
+
+/mob/living/carbon/human/dummy/mannequin/Life()		//Disables mannequin from doing more than processing this one Life(), stops organ processing
+	return
 
 /mob/living/carbon/human/skeleton
 	icon_state = "skeleton"

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -161,6 +161,9 @@
 		for(var/mattertype in .)
 			.[mattertype] *= amount // multiply matter appropriately
 
+/obj/item/ammo_casing/get_fall_damage()
+	return (amount >= min(maxamount, 10))
+
 //An item that holds casings and can be used to put them inside guns
 /obj/item/ammo_magazine
 	name = "magazine"
@@ -366,10 +369,25 @@
 		to_chat(usr, SPAN_NOTICE("[src] is already empty!"))
 		return
 	to_chat(usr, SPAN_NOTICE("You take out ammo from [src]."))
-	for(var/i=1 to stored_ammo.len)
-		var/obj/item/ammo_casing/C = removeCasing()
-		C.forceMove(target)
-		C.set_dir(pick(cardinal))
+
+	while(LAZYLEN(stored_ammo))
+
+		var/obj/item/ammo_casing/stack = removeCasing()
+		stack.forceMove(target)
+		stack.set_dir(pick(cardinal))
+
+		if(LAZYLEN(stored_ammo))
+			// We end on -1 since we already removed one
+			for(var/i = 1, i <= stack.maxamount - 1, i++)
+				if(!LAZYLEN(stored_ammo))
+					stack.update_icon()
+					break
+				var/obj/item/ammo_casing/AC = removeCasing()
+				if(!stack.mergeCasing(AC, null, null, TRUE, TRUE))
+					insertCasing(AC)
+					stack.update_icon()
+					break
+
 	update_icon()
 
 /obj/item/ammo_magazine/proc/get_label(value)

--- a/html/changelogs/AutoChangeLog-pr-8565.yml
+++ b/html/changelogs/AutoChangeLog-pr-8565.yml
@@ -1,0 +1,5 @@
+author: Mycah142
+delete-after: true
+changes:
+  - bugfix: Mannequins no longer process Life() or sanity, nor appear on Baptismal
+      record


### PR DESCRIPTION
## About The Pull Request
Original Author: VmpOS2NHSkhkejA9, https://github.com/discordia-space/CEV-Eris/pull/8561

A collection of adjustments to stacks and ammo boxes to make it harder to deal hundreds of damage by dropping rods and emptying ammo boxes onto people's heads:

- Dumping ammo from a box stacks it instead of splitting it into hundreds of separate items
- Ammo piles do not deal damage when falling on people unless there are at least 10 casings in the pile.
- Stacks of rods or material sheets will merge with other stacks on their tile when created and when crossing them.
- Damage from stacks falling on someone scales with the amount in the stack

Of note:
- Osmium deals more damage than other materials when falling on people.

What this PR does NOT do is fix the root problems with erismed that make this change necessary. Erismed runs into serious issues when dealing with lots of small chip damage and ends up dealing far more damage than it should. This simply makes it more difficult to abuse such issues.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Being able to decapitate people instantly with a stack of steel and a conveyor belt is probably bad.

You couldn't really decapitate people with ammo boxes, but you could still deal upwards of 600 damage in a single click. Which also happens to be not a good thing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
- Dumped ammoboxes and magazines. Casings were properly stacked. People only took marginal damage when boxes were dumped on their heads.
- Dragged sheets of materials on top of other sheets. They merged properly.
- Crafted rods individually, they all merged into a single stack.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
tweak: Ammo is compressed into stacks when dumped from boxes and magazines.
tweak: Material stacks merge when moving over each other and when created.
balance: Ammo piles deal no fall damage unless there's 10 or more casings in the pile.
balance: Stacks deal fall damage based on the number of sheets in the stack.
balance: Osmium deals 2.5x more fall damage than other stack types.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
