### PR TITLE
Poison/Wound Update/Fix (#8566)

### DIFF
--- a/code/__DEFINES/chemistry.dm
+++ b/code/__DEFINES/chemistry.dm
@@ -59,6 +59,7 @@
 #define CE_ONCOCIDAL        "anticancer"
 #define CE_BRAINHEAL        "neural tissue restoration"
 #define CE_EYEHEAL          "sensory organ regeneration stimulant"
+#define CE_GENEHEAL        "genecode restoration"
 
 // Chem effects for robotic/assisted organs
 #define CE_MECH_STABLE 		"cooling"

--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -74,11 +74,13 @@
 
 #define ISODD(x) (x % 2 != 0)
 
+#define NFRACT(tofract) (tofract - round(tofract)) // I live in agony
+
 //Probability based rounding that makes whole numbers out of decimals based on luck.
 //The decimal value is the probability to be rounded up.
 //Eg a value of 1.37 has a 37% chance to become 2, otherwise it is 1
 //Useful for game balance matters where the gulf caused by consistent rounding is too much
-#define ROUND_PROB(val) (val - (val % 1) + prob((val % 1) * 100))
+#define ROUND_PROB(val) (val - (NFRACT(val)) + prob(NFRACT(val) * 100))
 
 #define RAND_DECIMAL(lower, upper) (rand(0, upper - lower) + lower)
 

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -124,8 +124,8 @@
 /obj/item/organ/internal/take_damage(amount, damage_type = BRUTE, wounding_multiplier = 1, silent = FALSE, sharp = FALSE, edge = FALSE)	//Deals damage to the organ itself
 	if(!damage_type || status & ORGAN_DEAD)
 		return FALSE
-
-	var/wound_count = max(0, ROUND_PROB(amount / (damage_type == BRUTE || damage_type == BURN ? 4 : 8)))	// At base values, every 8 points of damage is 1 wound, or 4 if brute or burn.
+	var/fixed = amount / (damage_type == BRUTE || damage_type == BURN ? 4 : 8)
+	var/wound_count = max(0, ROUND_PROB(fixed))	// At base values, every 8 points of damage is 1 wound, or 4 if brute or burn.
 
 	if(!wound_count)
 		return FALSE
@@ -139,8 +139,6 @@
 			//LAZYREMOVE(possible_wounds, choice) // If this is commented out, we can get a higher severity of a single wound
 			if(!LAZYLEN(possible_wounds))
 				break
-
-		owner.custom_pain("Something inside your [parent.name] hurts a lot.", 0)		// Let em know they're hurting
 
 		return TRUE
 	return FALSE

--- a/code/modules/organs/internal/internal_wounds/_internal_wound.dm
+++ b/code/modules/organs/internal/internal_wounds/_internal_wound.dm
@@ -64,6 +64,12 @@
 
 	START_PROCESSING(SSinternal_wounds, src)
 
+	var/obj/item/organ/O = parent
+	var/obj/item/organ/external/E = O.parent
+	var/mob/living/carbon/human/H = O.owner
+	if(((characteristic_flag & IWOUND_CAN_DAMAGE) || hal_damage) && H)
+		H.custom_pain("Something inside your [E.name] hurts a lot.", 0)
+
 /datum/component/internal_wound/UnregisterFromParent()
 	UnregisterSignal(parent, COMSIG_IWOUND_EFFECTS)
 	UnregisterSignal(parent, COMSIG_IWOUND_LIMB_EFFECTS)
@@ -94,8 +100,6 @@
 		if(current_progression_tick >= progression_threshold)
 			current_progression_tick = 0
 			progress()
-			if(H)
-				H.custom_pain("Something inside your [E.name] hurts a lot.", 0)
 
 	if(!H)
 		return
@@ -139,7 +143,11 @@
 /datum/component/internal_wound/proc/progress()
 	if(!((characteristic_flag & IWOUND_PROGRESS) || (characteristic_flag & IWOUND_AGGRAVATION)))
 		return
-
+	var/obj/item/organ/O = parent
+	var/obj/item/organ/external/E = parent ? O.parent : null
+	var/mob/living/carbon/human/H = parent ? O.owner : null
+	if(((characteristic_flag & IWOUND_CAN_DAMAGE) || hal_damage) && H)
+		H.custom_pain("Something inside your [E.name] hurts a lot.", 0)
 	if(severity < severity_max)
 		++severity
 	else

--- a/code/modules/organs/internal/internal_wounds/organic.dm
+++ b/code/modules/organs/internal/internal_wounds/organic.dm
@@ -354,3 +354,19 @@
 
 /datum/component/internal_wound/organic/permanent/nopain
 	hal_damage = 0
+
+/datum/component/internal_wound/organic/genedamage
+	name = "genetic damage"
+	treatments_chem = list(CE_GENEHEAL = 1)
+	characteristic_flag = IWOUND_AGGRAVATION // this wound is hidden
+	next_wound = /datum/component/internal_wound/organic/catastrophicgenedamage
+
+/datum/component/internal_wound/organic/catastrophicgenedamage
+	name = "catastrophic genetic damage"
+	severity_max = IORGAN_STANDARD_HEALTH
+	characteristic_flag = IWOUND_AGGRAVATION | IWOUND_CAN_DAMAGE
+	hal_damage = IWOUND_HEAVY_DAMAGE
+	treatments_chem = list(CE_GENEHEAL = 2)
+
+/datum/component/internal_wound/organic/catastrophicgenedamage/failure
+	name = "tissue failure"

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -207,6 +207,7 @@
 /datum/reagent/medicine/cryoxadone/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(M.bodytemperature < 170)
 		M.add_chemical_effect(CE_ONCOCIDAL, 1)
+		M.add_chemical_effect(CE_GENEHEAL, 1)
 		M.add_chemical_effect(CE_OXYGENATED, 1)
 		M.add_chemical_effect(CE_BLOODCLOT, 0.50)
 		M.add_chemical_effect(CE_ANTITOX, 2)
@@ -228,6 +229,7 @@
 /datum/reagent/medicine/clonexadone/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(M.bodytemperature < 170)
 		M.add_chemical_effect(CE_ONCOCIDAL, 1)
+		M.add_chemical_effect(CE_GENEHEAL, 2)
 		M.add_chemical_effect(CE_OXYGENATED, 1)
 		M.add_chemical_effect(CE_BLOODCLOT, 0.50)
 		M.add_chemical_effect(CE_ANTITOX, 2)
@@ -428,6 +430,7 @@
 
 /datum/reagent/medicine/ryetalyn/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.add_chemical_effect(CE_ONCOCIDAL, 2)
+	M.add_chemical_effect(CE_GENEHEAL, 1)
 /*
 	var/needs_update = M.mutations.len > 0
 
@@ -658,6 +661,7 @@
 	M.heal_organ_damage(2 * effect_multiplier, 2 * effect_multiplier, 5 * effect_multiplier, 5 * effect_multiplier)
 	M.add_chemical_effect(CE_TOXIN, -(2 + (M.chem_effects[CE_TOXIN] * 0.05)) * effect_multiplier)
 	M.add_chemical_effect(CE_ONCOCIDAL, 2)
+	M.add_chemical_effect(CE_GENEHEAL, 2)
 	if(dose > 3)
 		M.status_flags &= ~DISFIGURED
 	if(dose > 10)

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -54,8 +54,26 @@
 	strength = 1
 	nerve_system_accumulations = 60
 	addiction_chance = 20
-	heating_point = 523
+	heating_point = 723 // supposedly amatoxin is heat resistant so I raised its heat temp by 200 - vode-code
 	heating_products = list("toxin")
+
+/datum/reagent/toxin/amatoxin/on_mob_add(mob/living/L)
+	data["timestart"] = REALTIMEOFDAY
+	data["effectcount"] = 0
+
+/datum/reagent/toxin/amatoxin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
+	. = ..()
+	if(ishuman(M))
+		var/mob/living/carbon/human/poorsap = M
+		if(REALTIMEOFDAY > (data["timestart"] + (data["effectcount"] * 5 MINUTES)))
+			for(var/obj/item/organ/internal/tokill in poorsap.organ_list_by_process(OP_LIVER) | poorsap.organ_list_by_process(OP_KIDNEYS)) // amanitin is slow but it kills HARD.
+				tokill.add_wound(/datum/component/internal_wound/organic/genedamage)
+			data["effectcount"] += 1
+
+/datum/reagent/toxin/amatoxin/affect_ingest(mob/living/carbon/M, alien, effect_multiplier)
+	affect_blood(M, alien, effect_multiplier)	// amanitin doesn't metabolize in the digestive tract, instead absorbing nearly perfectly.
+
+	apply_sanity_effect(M, effect_multiplier)
 
 /datum/reagent/toxin/carpotoxin
 	name = "Carpotoxin"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR finalizes https://github.com/discordia-space/CEV-Eris/pull/8548 by making ROUND_PROB function properly and adds a type of wound that Amatoxins can use.
The wound, classified as "genetic damage", is cured by genetic heals, and is of Aggravated class, without passive progression.
Amatoxins apply this wound to the kidneys/liver once every five minutes, leading to a slow death that begins with a silent progression, and continues to progress in a painful manner once ten minutes pass, until the liver and kidneys are dead, and its pitifully low standard toxin strength finishes the job.
The necessary strength to start dealing damage has been reduced due to the re-introduced ability of ROUND_PROB.
Additionally, rectified inconsistent organ pain messages.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Eating bad mushrooms should eventually lead to your demise. Damage should Damage. Painless wounds that don't deal damage shouldn't be instantly notable.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
thoroughly tested blattedin and amanitin on disciples to check for damage values, tested amanita on self to check for organ pain messages.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
balance: eating toxic mushrooms is now a bad idea.
fix: fixed damage, probably.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
