### PR TITLE
Remove QDEL_IN from affecting cloner

### DIFF
--- a/code/modules/core_implant/cruciform/machinery/cloning.dm
+++ b/code/modules/core_implant/cruciform/machinery/cloning.dm
@@ -73,9 +73,6 @@
 	anim1.pixel_z = 32
 
 	update_icon()
-	QDEL_IN(src, 20)
-
-	// I don't know a good alternative that would be the equivalent of QDEL_NULL_IN. so. pls fix?
 	spawn(20)
 		qdel(anim0)
 		qdel(anim1)

--- a/code/modules/core_implant/cruciform/machinery/cloning.dm
+++ b/code/modules/core_implant/cruciform/machinery/cloning.dm
@@ -93,7 +93,6 @@
 	anim1.pixel_z = 32
 
 	update_icon()
-	// previous comment applies here
 	spawn(20)
 		qdel(anim0)
 		qdel(anim1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Making the cloner QDEL itself in 20 ticks is a little weird. This fixes #30 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cloner not deleting itself is good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![dreamseeker_DKVJ89Xqt4](https://github.com/user-attachments/assets/45029622-22f1-43c3-be4f-afe3c07f6aea)
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
fix: fixed cloner deleting itself
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
