### PR TITLE
Add Breakdown JMP, fix simple mob targeting, stop dead processing breakdowns

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -450,7 +450,7 @@
 			var/mob/living/exosuit/M = _target_mob
 			if(length(M.pilots))
 				return FALSE
-		else if(!L.stat || L.health >= (ishuman(L) ? CONFIG_GET(number/health_threshold_crit) : 0))
+		else if(!L.stat || L.health <= (ishuman(L) ? CONFIG_GET(number/health_threshold_crit) : TRUE))
 			return FALSE
 
 	if(istype(_target_mob, /obj/machinery/bot))

--- a/code/modules/sanity/breakdown.dm
+++ b/code/modules/sanity/breakdown.dm
@@ -55,7 +55,7 @@
 		var/obj/item/clothing/head/mindreader/MR = holder.owner.head
 		MR.extract_memory(holder.owner)
 	if(start_messages)
-		log_and_message_admins("[holder.owner] is affected by breakdown [name] with duration [duration/10] seconds.")
+		log_and_message_admins("[holder.owner] is affected by breakdown [name] with duration [duration/10] seconds. [ADMIN_JMP(holder.owner.loc)]")
 		to_chat(holder.owner, span(start_message_span, pick(start_messages)))
 	if(restore_sanity_pre)
 		holder.restoreLevel(restore_sanity_pre)

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -181,6 +181,8 @@ GLOBAL_VAR_INIT(GLOBAL_INSIGHT_MOD, 1)
 		. *= owner.stats.getStat(STAT_VIG) / STAT_LEVEL_MAX
 
 /datum/sanity/proc/handle_breakdowns()
+	if(owner.stat == DEAD)
+		return
 	for(var/datum/breakdown/B in breakdowns)
 		if(!B.update())
 			breakdowns -= B


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Due to some recent value changes, simple animals (such as hostile Onestar drones) were attacking Skeletal Remains in the Abandoned Fortress. This was due to a funny > boy facing the wrong way. As part of troubleshooting, I added an admin JMP link to find who is having a breakdown faster, and made it so a dead creature no longer starts handling new breakdowns.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfixes good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Trust me bro
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
add: Breakdown JMP
fix: Skeletal Remains no longer are simple mob targets
tweak: DEAD no longer handle new breakdowns
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
