### PR TITLE
Groin efficiency rises faster

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -639,7 +639,7 @@ default behaviour is:
 		if(H)
 			var/obj/item/organ/external/groin = H.get_organ(BP_GROIN)
 			if(groin.limb_efficiency <= 0)
-				to_chat(src, SPAN_WARNING("You are too damaged to be able to get up."))
+				to_chat(src, span_warning("You are too damaged to be able to get up."))
 				return FALSE
 			groinmult =  100 / groin.limb_efficiency // smaller mult the bigger the efficiency
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -635,8 +635,15 @@ default behaviour is:
 
 	if(resting)
 		is_busy = TRUE
+		var/groinmult = 1
+		if(H)
+			var/obj/item/organ/external/groin = H.get_organ(BP_GROIN)
+			if(groin.limb_efficiency <= 0)
+				to_chat(src, SPAN_WARNING("You are too damaged to be able to get up."))
+				return FALSE
+			groinmult =  100 / groin.limb_efficiency // smaller mult the bigger the efficiency
 
-		if(do_after(src, (stats.getPerk(PERK_PARKOUR) ? 0.2 SECONDS : 0.4 SECONDS), null, 0, 1, INCAPACITATION_DEFAULT, immobile = 0))
+		if(do_after(src, min((stats.getPerk(PERK_PARKOUR) ? 0.2 SECONDS : 0.4 SECONDS) * groinmult, 2 SECONDS), null, 0, 1, INCAPACITATION_DEFAULT, immobile = 0))
 			resting = FALSE
 			to_chat(src, span_notice("You are now getting up."))
 			update_lying_buckled_and_verb_status()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Originally by vode-code, located at https://github.com/discordia-space/CEV-Eris/pull/8567

This PR relocates internal wound tracking to the internal organs, rather than being a "globally applicable component".
Additionally, Parenchyma type wounds now process mutation index correctly.
This code is simpler than what it replaces, it just hides less of it behind procs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Simpler code for the same results is better, and fixes are good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Smacked Disciple as Artist with a hammer until the debug messages triggered, then scanned Disciple in body scanner, revealing correct data.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
fix: Parenchyma no longer bugs out when multiple types are applied to the same organ
refactor: Internal Wounds no longer use Component code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
