### PR TITLE
fix the ore processor (finally)

### DIFF
--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -153,16 +153,16 @@
 	// initialize static alloy_data list
 	if(!alloy_data)
 		alloy_data = list()
-		for(var/alloytype in typesof(/datum/alloy)-/datum/alloy)
+		for(var/alloytype in subtypesof(/datum/alloy))
 			alloy_data += new alloytype()
 
 	if(!ore_data || !ore_data.len)
-		for(var/oretype in typesof(/ore)-/ore)
+		for(var/oretype in subtypesof(/ore))
 			var/ore/OD = new oretype()
 			ore_data[OD.name] = OD
-	for(var/ore/OD in ore_data)
-		ores_processing[OD.name] = 0
-		ores_stored[OD.name] = 0
+	for(var/ore_name in ore_data)
+		ores_processing[ore_name] = 0
+		ores_stored[ore_name] = 0
 
 
 /obj/machinery/mineral/processing_unit/update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes ore processors not initializing its list of all ore names, which in turn fixes the following issues because of how integral that list is:
- inserted ores getting deleted without tallying up the stored number
- processor being completely unable to process ores
- stored ore counts not being listed (not that they'd have shown anything besides 0)
- processing mode buttons not appearing (the relevant buttons would still appear if an alloy button was pressed but be completely nonfunctional)

fixes #121 
(was closed immediately as "not an issue on MonkEris" but seemed to occur on yesterday's live playtest so it is likely still an issue.)

## Why It's Good For The Game

the game works

## Testing

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->
<img width="848" height="651" alt="image" src="https://github.com/user-attachments/assets/1df9c682-d285-4cd7-bf5e-9c264801bf28" />

## Changelog
:cl
fix: fixed ore processor being completely nonfunctional
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
