### PR TITLE
Add "Get" atom movable verb

### DIFF
--- a/code/datums/topic/admin.dm
+++ b/code/datums/topic/admin.dm
@@ -521,6 +521,20 @@
 	var/mob/observer/ghost/ghost = usr
 	ghost.ManualFollow(target)
 
+/datum/admin_topic/admingetmovable
+	keyword = "admingetmovable"
+	require_perms = list(R_ADMIN)
+
+/datum/admin_topic/admingetmovable/Run(list/input)
+	var/atom/movable/AM = locate(input["admingetmovable"])
+	if(QDELETED(AM))
+		return
+	if (isnull(usr.loc))
+		to_chat(usr, "Can't move to nullspace!")
+		return
+
+	AM.forceMove(get_turf(usr))
+
 /datum/admin_topic/adminplayerobservecoodjump
 	keyword = "adminplayerobservecoodjump"
 	require_perms = list(R_ADMIN)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -434,3 +434,8 @@
 	SHOULD_CALL_PARENT(TRUE)
 	. = list()
 	SEND_SIGNAL_OLD(src, COMSIG_ATOM_UPDATE_OVERLAYS, .)
+
+/atom/movable/vv_get_dropdown()
+	. = ..()
+	. += "<option value='byond://?_src_=holder;[HrefToken()];adminplayerobservefollow=[REF(src)]'>Follow</option>"
+	. += "<option value='byond://?_src_=holder;[HrefToken()];admingetmovable=[REF(src)]'>Get</option>"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -76,6 +76,7 @@ GLOBAL_LIST_INIT(admin_verbs_debug, list(
 	/client/proc/view_runtimes,
 	/client/proc/spawn_disciple,
 	/client/proc/delete_npcs,
+	/client/proc/get, /*Teleport atom to where usr is*/
 	/client/proc/map_template_load,
 	/client/proc/map_template_load_on_new_z,
 	/client/proc/map_template_upload,

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -429,3 +429,16 @@
 		return
 	if(tgui_alert(usr, "Are you absolutely sure you want to reload the configuration from the default path on the disk, wiping any in-round modifications?", "Really reset?", list("No", "Yes")) == "Yes")
 		config.admin_reload()
+
+/client/proc/get(atom/movable/A)
+	set category = "Debug"
+	set name = "Get"
+
+	if (isnull(usr.loc))
+		to_chat(usr, "Can't move to nullspace!")
+		return
+
+	if(QDELETED(A))
+		return
+
+	A.forceMove(get_turf(usr))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a verb that lets you get 
## Why It's Good For The Game

Useful thing for getting atoms n stuff

## Testing

https://github.com/user-attachments/assets/71e6317c-5184-4e4f-83bd-3212b4b42e10

## Changelog
:cl:
add: "Get" verb to verb context menu and VV dropdown
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
