### PR TITLE
Fix ckeys showing in announce_ghost_joinleave messages

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -68,7 +68,7 @@
 	if(!player || (!isghost(player.mob) && !aibound))
 		return
 
-	announce_ghost_joinleave(player, 0, "They have taken control over a maintenance drone.")
+	announce_ghost_joinleave(player.mob, 0, "They have taken control over a maintenance drone.")
 	visible_message("\The [src] churns and grinds as it lurches into motion, disgorging a shiny new drone after a few moments.")
 	flick("h_lathe_leave",src)
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -373,10 +373,11 @@ var/list/intents = list(I_HELP,I_DISARM,I_GRAB,I_HURT)
 					name = M.real_name
 		if(!name)
 			name = (C.holder && C.holder.fakekey) ? C.holder.fakekey : C.key
+		var/verby = pick("skulks","lurks","prowls","creeps","stalks")
 		if(joined_ghosts)
-			deadchat_broadcast("The ghost of [span_name("[name]")] now [pick("skulks","lurks","prowls","creeps","stalks")] among the dead. [message]")
+			deadchat_broadcast("The ghost of [span_name("[name]")] now [verby] among the dead. [message]")
 		else
-			deadchat_broadcast("[span_name("[name]")] no longer [pick("skulks","lurks","prowls","creeps","stalks")] in the realm of the dead. [message]")
+			deadchat_broadcast("[span_name("[name]")] no longer [verby] in the realm of the dead. [message]")
 
 /mob/proc/switch_to_camera(obj/machinery/camera/C)
 	if (!C.can_use() || stat || (get_dist(C, src) > 1 || machine != src || blinded || !canmove))

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -148,7 +148,6 @@
 				to_chat(src, span_danger("Could not locate an observer spawn point. Use the Teleport verb to jump to the station map."))
 			observer.timeofdeath = world.time // Set the time of death so that the respawn timer works correctly.
 
-			announce_ghost_joinleave(src)
 			observer.icon = client.prefs.update_preview_icon()
 			observer.alpha = 127
 
@@ -165,6 +164,7 @@
 
 			observer.client.create_UI(observer.type)
 			qdel(src)
+			announce_ghost_joinleave(observer)
 
 			return 1
 

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -798,14 +798,13 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		log_game("[usr.key] AM failed due to disconnect.")
 		return
 
+	announce_ghost_joinleave(src, 0)
 
 	var/mob/new_player/M = new /mob/new_player()
 	if(!client)
 		log_game("[usr.key] AM failed due to disconnect.")
 		qdel(M)
 		return
-
-	announce_ghost_joinleave(M, 0)
 
 	M.key = key
 	if(M.client)

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -199,7 +199,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			message_admins("[key_name_admin(usr)] has ghosted. [ADMIN_JMP(src)]")
 			log_game("[key_name_admin(usr)] has ghosted.")
 			ghostize(0)
-			announce_ghost_joinleave(client)
+			announce_ghost_joinleave(src)
 
 /mob/observer/ghost/can_use_hands()
 /mob/observer/ghost/is_active()
@@ -798,13 +798,14 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		log_game("[usr.key] AM failed due to disconnect.")
 		return
 
-	announce_ghost_joinleave(client, 0)
 
 	var/mob/new_player/M = new /mob/new_player()
 	if(!client)
 		log_game("[usr.key] AM failed due to disconnect.")
 		qdel(M)
 		return
+
+	announce_ghost_joinleave(M, 0)
 
 	M.key = key
 	if(M.client)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #141 

Some of the calls to `announce_ghost_joinleave` were calling with client instead of mob.

- Fixes `announce_ghost_joinleave` showing the ckey of the person observing instead of the mob they're observing as.
- Shimmys around the verb for "stalking" the dead variants.


## Why It's Good For The Game

Fix good. can i have a pass on explaining why some of these are good for the game,,, cause it's kinda obvious. bugfix good.

## Testing

<img width="397" height="93" alt="image" src="https://github.com/user-attachments/assets/25adcf9c-92fa-4bb3-afe3-3e92f5a8fe91" />

## Changelog
:cl:
fix: `announce_ghost_joinleave` should no longer show the ckey of the observing mob.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
