### PR TITLE
Add missing "update_ping" verb to client.

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -1638,6 +1638,7 @@
 #include "code\modules\client\preference_setup\matchmaking\relations.dm"
 #include "code\modules\client\preference_setup\matchmaking\relations_types.dm"
 #include "code\modules\client\preference_setup\occupation\occupation.dm"
+#include "code\modules\client\verbs\ping.dm"
 #include "code\modules\client\verbs\typing.dm"
 #include "code\modules\clothing\chameleon.dm"
 #include "code\modules\clothing\clothing.dm"

--- a/code/modules/client/verbs/ping.dm
+++ b/code/modules/client/verbs/ping.dm
@@ -1,0 +1,22 @@
+/client/verb/update_ping(time as num)
+	set instant = TRUE
+	set name = ".update_ping"
+	var/ping = pingfromtime(time)
+	lastping = ping
+	if (!avgping)
+		avgping = ping
+	else
+		avgping = MC_AVERAGE_SLOW(avgping, ping)
+
+/client/proc/pingfromtime(time)
+	return ((world.time+world.tick_lag*TICK_USAGE_REAL/100)-time)*100
+
+/client/verb/display_ping(time as num)
+	set instant = TRUE
+	set name = ".display_ping"
+	to_chat(src, span_notice("Round trip ping took [round(pingfromtime(time),1)]ms"))
+
+/client/verb/ping()
+	set name = "Ping"
+	set category = "OOC"
+	winset(src, null, "command=.display_ping+[world.time+world.tick_lag*TICK_USAGE_REAL/100]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Was missed during PR https://github.com/Monkestation/Monkeris/pull/115

Fixes `.update_ping 1894.283767862346782` (and similar) from showing up in the verb box.

## Why It's Good For The Game


## Testing


## Changelog
:cl:
add: missing update_ping verb.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
