### PR TITLE
Moves ghostchat follow prompts to the start of messages

### DIFF
--- a/code/game/antagonist/antagonist_factions.dm
+++ b/code/game/antagonist/antagonist_factions.dm
@@ -153,7 +153,7 @@
 		if(!M.client)
 			continue
 		if((M.antagHUD && M.get_preference_value(/datum/client_preference/ghost_ears) == GLOB.PREF_ALL_SPEECH) || is_admin(M))
-			to_chat(M, "[text] [ghost_follow_link(user, M)]")
+			to_chat(M, "[ghost_follow_link(user, M)] [text]")
 
 	log_say("[user.name]/[user.key] (REV [name]) : [message]")
 

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -182,7 +182,7 @@
 	if(. != speaker.real_name && !isAI(speaker))
 	 //Announce computer and various stuff that broadcasts doesn't use it's real name but AI's can't pretend to be other mobs.
 		. = "[speaker.real_name] ([.])"
-	return "[.] [ghost_follow_link(speaker, src)]"
+	return "[ghost_follow_link(speaker, src)] [.]"
 
 /proc/say_timestamp()
 	return "<span class='say_quote'>\[[stationtime2text()]\]</span>"

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -202,7 +202,7 @@
 
 /mob/observer/ghost/hear_broadcast(datum/language/language, mob/speaker, speaker_name, message)
 	if(speaker.name == speaker_name || antagHUD)
-		to_chat(src, "<i><span class='game say'>[language.name], [span_name("[speaker_name]")] [ghost_follow_link(speaker, src)] [message]</span></i>")
+		to_chat(src, "<i><span class='game say'>[language.name], [ghost_follow_link(speaker, src)] [span_name("[speaker_name]")] [message]</span></i>")
 	else
 		to_chat(src, "<i><span class='game say'>[language.name], [span_name("[speaker_name]")] [message]</span></i>")
 

--- a/code/modules/mob/language/synthetic.dm
+++ b/code/modules/mob/language/synthetic.dm
@@ -27,7 +27,7 @@
 		if (isangel(M))
 			M.show_message("[message_start] [message_body]", 2)
 		if(!isnewplayer(M) && !isbrain(M)) //No meta-evesdropping
-			M.show_message("[message_start] [ghost_follow_link(speaker, M)] [message_body]", 2)
+			M.show_message("[ghost_follow_link(speaker, M)] [message_start] [message_body]", 2)
 
 	for (var/mob/living/S in GLOB.living_mob_list)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
here byou go fleepy
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fleepy asked for it
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
works
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
tweak: The (f) prompt in observer/ghost chat is now closer to the start of messages
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
