### PR TITLE
Diagonal Movement Toggle

### DIFF
--- a/code/_global_vars/configuration.dm
+++ b/code/_global_vars/configuration.dm
@@ -9,3 +9,4 @@ GLOBAL_VAR_INIT(dooc_allowed, TRUE)
 GLOBAL_VAR_INIT(dsay_allowed, TRUE)
 GLOBAL_VAR_INIT(enter_allowed, TRUE)
 
+GLOBAL_VAR_INIT(diagonal_movement, FALSE)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -695,6 +695,21 @@ var/global/floorIsLava = 0
 	log_admin("[key_name(usr)] toggled Dead OOC.")
 	message_admins("[key_name_admin(usr)] toggled Dead OOC.", 1)
 
+/datum/admins/proc/togglediagonalmovement()
+	set category = "Server"
+	set desc="Toggle Diagonal Movement."
+	set name="Toggle Diagonal Movement"
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	GLOB.diagonal_movement = !( GLOB.diagonal_movement )
+	for (var/client/client in GLOB.clients)
+		client.CAN_MOVE_DIAGONALLY = GLOB.diagonal_movement
+	log_admin("[key_name(usr)] toggled diagonal movement ([(GLOB.diagonal_movement ? "ON" : "OFF")]).")
+	message_admins("[key_name_admin(usr)] toggled diagonal movement ([(GLOB.diagonal_movement ? "ON" : "OFF")]).")
+
+
 /datum/admins/proc/startnow()
 	set category = "Server"
 	set desc="Start the round RIGHT NOW"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -196,6 +196,7 @@ GLOBAL_LIST_INIT(admin_verbs_admin, list(
 	/datum/admins/proc/togglelooc,
 	/datum/admins/proc/toggledsay,
 	/datum/admins/proc/toggleoocdead,
+	/datum/admins/proc/togglediagonalmovement,
 	/datum/admins/proc/toggleenter,
 	/datum/admins/proc/toggleAI,
 	/datum/admins/proc/toggleguests,

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -398,6 +398,8 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		host = key
 		world.update_status()
 
+	CAN_MOVE_DIAGONALLY = GLOB.diagonal_movement
+
 	if(holder)
 		add_admin_verbs()
 		admin_memo_show()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows admins to toggle on or off diagonal movement 

## Why It's Good For The Game

for the funnies!

## Testing

Compiles, verb show up

## Changelog
:cl:
admin: admins can now toggle diagonal movement via Server verb tab
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
