### PR TITLE
Reduces Drunk screensway by 50%

### DIFF
--- a/code/modules/mob/animations.dm
+++ b/code/modules/mob/animations.dm
@@ -28,8 +28,8 @@ note dizziness decrements automatically in the mob's Life() proc.
 	while(dizziness > 100)
 		if(client)
 			var/amplitude = dizziness*(sin(dizziness * 0.044 * world.time) + 1) / 70
-			client.pixel_x = amplitude * sin(0.008 * dizziness * world.time)
-			client.pixel_y = amplitude * cos(0.008 * dizziness * world.time)
+			client.pixel_x = amplitude * sin(0.004 * dizziness * world.time)
+			client.pixel_y = amplitude * cos(0.004 * dizziness * world.time)
 
 		sleep(1)
 	//endwhile - reset the pixel offsets to zero


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Our old bay screenshake is genuinely nauseating in real life and gets almost unbearable when properly drunk, to the point that I've frequently given up and left my char in a corner while I do something irl, waiting for dizziness stacks to clear 

Ideally at some point someone would refactor our screenshake to be the less nauseating ease in version from tg/modern baylikes
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
got drunk, sway was less painful(but still snaps around, which sucks but whatever)
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
tweak: reduces screenshake from dizziness by 50%
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
