### PR TITLE
fix: produce bag group grown plants by name

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -156,6 +156,14 @@
 		/obj/item/reagent_containers/food/snacks/egg,
 		/obj/item/reagent_containers/food/snacks/meat)
 
+// Override grouping key to group grown items by plantname instead of just type
+/obj/item/storage/bag/produce/get_item_grouping_key(obj/item/I)
+	if(istype(I, /obj/item/reagent_containers/food/snacks/grown))
+		var/obj/item/reagent_containers/food/snacks/grown/G = I
+		if(G.plantname)
+			return "[I.type]|[G.plantname]" // Use combination of type and plantname
+	return I.type
+
 
 // -----------------------------
 //        Sheet Snatcher

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -94,6 +94,11 @@
 	if (itemCount)
 		item.maptext = "<font color='white'>[itemCount]</font>"
 
+// Helper proc to get grouping key for items in display_contents_with_number mode
+// Can be overridden by subtypes to customize grouping behavior
+/obj/item/storage/proc/get_item_grouping_key(obj/item/I)
+	return I.type
+
 /obj/item/storage/proc/generateHUD(datum/hud/data)
 	RETURN_TYPE(/atom/movable/hud_element)
 	var/atom/movable/hud_element/main = new("storage")
@@ -165,7 +170,7 @@
 			filtered_contents_last = new //last of x item type in storage
 			filtered_contents_count = new //total number of x item type in storage
 			for(var/obj/item/I in contents) //count items and remember last item for each type
-				var/item_type = I.type
+				var/item_type = get_item_grouping_key(I)
 				if (filtered_contents_count[item_type])
 					filtered_contents_count[item_type]++
 				else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR addresses issue with produce bag (botany bags) grouping all harvested/grown plants, under same slot in UI. 
As for now, it properly splitted meat and seeds, but all plants were always in the same slot, acting like stack, so to access certain type of plant, you needed to take out every other plant that was ontop of this slot

This PR introduces new proc that allows for custom grouping key, which can be configured in respective storage, and configures that for produce bag

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It makes agricultural work easier and less tedious, as you don't need to juggle plants in plant bag, just to access one you currently need.
Everything else works like before.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

After change: 

<img width="1037" height="706" alt="image" src="https://github.com/user-attachments/assets/0850bb9c-5628-49f9-a449-7096631f4779" />


<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
fix: produce bag groups grown plants by name
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
