### PR TITLE
fix: stat panel flickering, stat panel items not interactable, disposal unit ui fix

### DIFF
--- a/code/controllers/subsystems/statpanel.dm
+++ b/code/controllers/subsystems/statpanel.dm
@@ -160,7 +160,7 @@ SUBSYSTEM_DEF(statpanels)
 						continue
 					else
 						// This works but we need to figure out caching later
-						turfitems += list(list("[turf_content.name]", "[ma2html(turf_content, target_mob)]"))
+						turfitems += list(list("[turf_content.name]", "\ref[turf_content]", "[ma2html(turf_content, target_mob)]"))
 				turfitems = url_encode(json_encode(turfitems))
 				target << output("[turfitems];", "statbrowser:update_listedturf")
 		if(MC_TICK_CHECK)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -942,6 +942,7 @@
 	if(href_list["statpanel_item_click"])
 		var/mouseparams = list2params(paramslist)
 		usr_client.Click(src, loc, null, mouseparams)
+		return TRUE // prevent NanoUI Topic chain (CouldUseTopic/set_machine) from firing
 
 /// Called after we wrench/unwrench this object
 /obj/proc/wrenched_change()

--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -794,25 +794,70 @@ function update_listedturf(TC) {
 
 function draw_listedturf() {
 	const statcontentdiv = document.getElementById("statcontent");
-	statcontentdiv.textContent = "";
+	const existingContainer = document.getElementById("turf-container");
 
+	// If the same items are present (by name), only refresh image srcs and refs.
+	// Screen objects from ma2html expire after 5s so refs must be updated each tick,
+	// but clearing the DOM on every tick causes visible flickering.
+	if (existingContainer) {
+		const existingItems = existingContainer.querySelectorAll('.turf-item');
+		if (existingItems.length === turfcontents.length) {
+			let sameStructure = true;
+			for (let i = 0; i < turfcontents.length; i++) {
+				if (existingItems[i].getAttribute('data-turf-name') !== turfcontents[i][0]) {
+					sameStructure = false;
+					break;
+				}
+			}
+			if (sameStructure) {
+				for (let i = 0; i < turfcontents.length; i++) {
+					const ref = turfcontents[i][1];
+					const html = turfcontents[i][2];
+					const item = existingItems[i];
+					item.setAttribute('data-turf-ref', ref);
+					const iconSpan = item.querySelector('.turf-icon');
+					if (iconSpan) {
+						const tmpDiv = document.createElement('div');
+						tmpDiv.innerHTML = html;
+						const newImg = tmpDiv.querySelector('img');
+						const existingImg = iconSpan.querySelector('img');
+						if (newImg && existingImg) {
+							existingImg.src = newImg.src;
+						} else {
+							iconSpan.innerHTML = html;
+						}
+					}
+				}
+				return;
+			}
+		}
+	}
+
+	// Full redraw: item list changed or first render
+	statcontentdiv.textContent = "";
 	const container = document.createElement("div");
+	container.id = "turf-container";
 
 	for (let i = 0; i < turfcontents.length; i++) {
 		const part = turfcontents[i];
-		const [label, html] = part;
+		const label = part[0];
+		const ref = part[1];
+		const html = part[2];
 
 		const b = document.createElement("div");
-		b.className = "link";
-		b.innerHTML = `<div class="turf-entry-label">${label}</div>${html}`;
-		b.onmousedown = (e => {
+		b.className = "link turf-item";
+		b.setAttribute('data-turf-name', label);
+		b.setAttribute('data-turf-ref', ref);
+		b.innerHTML = `<div class="turf-entry-label">${label}</div><span class="turf-icon">${html}</span>`;
+		b.onmousedown = (e) => {
 			e.preventDefault();
-			let clickcatcher = "?src=" + part[1] + ";statpanel_item_click=1";
+			const currentRef = b.getAttribute('data-turf-ref');
+			let clickcatcher = "?src=" + currentRef + ";statpanel_item_click=1";
 			if (e.shiftKey) clickcatcher += ";statpanel_item_shiftclick=1";
 			if (e.ctrlKey) clickcatcher += ";statpanel_item_ctrlclick=1";
 			if (e.altKey) clickcatcher += ";statpanel_item_altclick=1";
 			window.location.href = clickcatcher;
-		});
+		};
 
 		container.appendChild(b);
 	}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR addresses #252 issue regarding statpanel flickering and being not interactable

With this change, stat panel (floor clicked with alt) stops rerendering whole DOM in intervals and propagates events through proper refs to the atoms interacted with.

This PR also fixes disposals UI, which after interaction through statpanel, was reopening on its own

Known issues:
Canister is the only thing that I've found that wasn't properly working when interacted via statpanel, but comments dettered me from touching that, as I have no clue if it's still relevant or no: 
<img width="992" height="221" alt="image" src="https://github.com/user-attachments/assets/b6e0d8c4-dddd-4eb9-9804-e6709b89971d" />

Fix for that is easy as just adding `..()` in the beginning of that function, but I'm leaving that up to you.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #252

This PR improves existing component that's currently not working and of course stat panel is really useful for accessing specific things in areas full of other items.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

I guess movie would be more usefull in this case, cause everything looks exactly the same, but it's working, not flickering, you can pickup, pull, examine items etc.

<img width="968" height="803" alt="image" src="https://github.com/user-attachments/assets/3f40f8f5-90cd-40a4-ade9-53dd45f11167" />


<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:

fix: stat panel flickering
fix: stat panel items not interactable
fix: disposal unit ui fix

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
