### PR TITLE
Fix/character prefs not loading

### DIFF
--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -205,7 +205,8 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 		mob_species = GLOB.all_species[pref.species]
 		if(new_s_tone && CanUseTopic(user))
-			pref.s_tone = 35 - max(min(round(new_s_tone), 220), 1)
+			pref.s_tone = 35 - max(min(round(new_s_tone), 225), 1)
+			pref.preview_should_rebuild_organs = TRUE
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 
 	else if(href_list["skin_color"])

--- a/code/modules/client/preference_setup/general/04_equipment.dm
+++ b/code/modules/client/preference_setup/general/04_equipment.dm
@@ -175,8 +175,8 @@
 
 	return ..()
 
-/datum/category_item/player_setup_item/physical/equipment/update_setup(savefile/preferences, savefile/character)
-	if(preferences["version"]  <= 16)
+/datum/category_item/player_setup_item/physical/equipment/update_setup(pref_version, savefile/character)
+	if(pref_version <= 16)
 		var/list/old_index_to_backpack_type = list(
 			/decl/backpack_outfit/nothing,
 			/decl/backpack_outfit/backsport,

--- a/code/modules/client/preference_setup/global/05_settings.dm
+++ b/code/modules/client/preference_setup/global/05_settings.dm
@@ -15,12 +15,17 @@
 	to_file(S["default_slot"], pref.default_slot)
 	to_file(S["preference_values"], pref.preference_values)
 
-/datum/category_item/player_setup_item/player_global/settings/update_setup(savefile/preferences, savefile/character)
-	if(preferences["version"] < 16)
+/datum/category_item/player_setup_item/player_global/settings/update_setup(pref_version, savefile/character)
+	if(pref_version < 16)
 		var/list/preferences_enabled
 		var/list/preferences_disabled
-		from_file(preferences["preferences"], preferences_enabled)
-		from_file(preferences["preferences_disabled"], preferences_disabled)
+		// The old preferences/preferences_disabled keys live at cd="/" of the
+		// same file. Temporarily navigate there, read, then restore cd.
+		var/old_cd = character.cd
+		character.cd = "/"
+		from_file(character["preferences"], preferences_enabled)
+		from_file(character["preferences_disabled"], preferences_disabled)
+		character.cd = old_cd
 
 		if(!istype(preferences_enabled))
 			preferences_enabled = list()
@@ -36,6 +41,7 @@
 			else
 				pref.preference_values[cp.key] = cp.default_value
 		return 1
+	return 0
 
 /datum/category_item/player_setup_item/player_global/settings/sanitize_preferences()
 	// Ensure our preferences are lists.

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -287,8 +287,8 @@ GLOBAL_LIST_EMPTY(gear_datums)
 		return TOPIC_REFRESH
 	return ..()
 
-/datum/category_item/player_setup_item/loadout/update_setup(savefile/preferences, savefile/character)
-	if(preferences["version"] < 14)
+/datum/category_item/player_setup_item/loadout/update_setup(pref_version, savefile/character)
+	if(pref_version < 14)
 		var/list/old_gear = character["gear"]
 		if(istype(old_gear)) // During updates data isn't sanitized yet, we have to do manual checks
 			if(!istype(pref.gear_list)) pref.gear_list = list()
@@ -296,7 +296,7 @@ GLOBAL_LIST_EMPTY(gear_datums)
 			pref.gear_list[1] = old_gear
 		return 1
 
-	if(preferences["version"] < 15)
+	if(pref_version < 15)
 		if(istype(pref.gear_list))
 			// Checks if the key of the pref.gear_list is a list.
 			// If not the key is replaced with the corresponding value.

--- a/code/modules/client/preference_setup/matchmaking/relations.dm
+++ b/code/modules/client/preference_setup/matchmaking/relations.dm
@@ -55,8 +55,8 @@
 		return TOPIC_REFRESH
 	return ..()
 
-/datum/category_item/player_setup_item/relations/update_setup(savefile/preferences, savefile/character)
-	if(preferences["version"] < 18)
+/datum/category_item/player_setup_item/relations/update_setup(pref_version, savefile/character)
+	if(pref_version < 18)
 		// Remove old relation types
 		for(var/i in pref.relations)
 			var/f = FALSE

--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -92,9 +92,9 @@ var/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 	for(var/datum/category_group/player_setup_category/PS in categories)
 		PS.save_preferences(S)
 
-/datum/category_collection/player_setup_collection/proc/update_setup(savefile/preferences, savefile/character)
+/datum/category_collection/player_setup_collection/proc/update_setup(pref_version, savefile/character)
 	for(var/datum/category_group/player_setup_category/PS in categories)
-		. = PS.update_setup(preferences, character) || .
+		. = PS.update_setup(pref_version, character) || .
 
 /datum/category_collection/player_setup_collection/proc/header()
 	var/dat = ""
@@ -164,9 +164,9 @@ var/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 	for(var/datum/category_item/player_setup_item/PI in items)
 		PI.save_preferences(S)
 
-/datum/category_group/player_setup_category/proc/update_setup(savefile/preferences, savefile/character)
+/datum/category_group/player_setup_category/proc/update_setup(pref_version, savefile/character)
 	for(var/datum/category_item/player_setup_item/PI in items)
-		. = PI.update_setup(preferences, character) || .
+		. = PI.update_setup(pref_version, character) || .
 
 /datum/category_group/player_setup_category/proc/content(mob/user)
 	. = "<table style='width:100%'><tr style='vertical-align:top'><td style='width:50%'>"
@@ -238,7 +238,7 @@ var/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 /*
 * Called when the item is asked to update user/global settings
 */
-/datum/category_item/player_setup_item/proc/update_setup(savefile/preferences, savefile/character)
+/datum/category_item/player_setup_item/proc/update_setup(pref_version, savefile/character)
 	return 0
 
 /datum/category_item/player_setup_item/proc/content()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -232,13 +232,11 @@
 	character.backpack_setup = new(backpack, backpack_metadata["[backpack]"])
 
 	if (preview_should_rebuild_organs || !is_preview_copy)
-		character.force_update_limbs()
 		character.update_mutations(0)
 		character.update_implants(0)
 		preview_should_rebuild_organs = FALSE
 
-
-	character.update_body(0)
+	character.force_update_limbs()
 	character.update_underwear(0)
 
 	character.update_hair(0)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -70,7 +70,9 @@
 
 /datum/preferences/proc/load_and_update_character(slot)
 	load_character(slot)
-	if(update_setup(loaded_preferences, loaded_character))
+	var/migrated = update_setup(savefile_version, loaded_character)
+	if(loaded_character)	del(loaded_character)
+	if(migrated)
 		save_preferences()
 		save_character()
 
@@ -269,6 +271,8 @@
 	dat += "<body>"
 	dat += "<tt><center>"
 
+	if(loaded_preferences)	del(loaded_preferences)
+	if(loaded_character)	del(loaded_character)
 	var/savefile/S = new /savefile(path)
 	if(S)
 		dat += "<b>Select a character slot to load</b><hr>"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -232,11 +232,12 @@
 	character.backpack_setup = new(backpack, backpack_metadata["[backpack]"])
 
 	if (preview_should_rebuild_organs || !is_preview_copy)
+		character.force_update_limbs()
 		character.update_mutations(0)
 		character.update_implants(0)
 		preview_should_rebuild_organs = FALSE
 
-	character.force_update_limbs()
+	character.update_body(0)
 	character.update_underwear(0)
 
 	character.update_hair(0)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -14,6 +14,8 @@
 		return 0
 	if(!fexists(path))		return 0
 	debug_world_log("LOADING PREFS FOR [usr]/[usr?.ckey] - PATH: [path]")
+	if(loaded_preferences)	del(loaded_preferences)
+	if(loaded_character)	del(loaded_character)
 	var/savefile/S = new /savefile(path)
 	if(!S)					return 0
 	S.cd = "/"
@@ -30,13 +32,15 @@
 			to_chat(client, span_warning("You're attempting to save your preferences a little too fast. Wait half a second, then try again."))
 		return 0
 	debug_world_log("SAVING PREFS FOR [usr]/[usr?.ckey] - PATH: [path]")
+	if(loaded_preferences)	del(loaded_preferences)
+	if(loaded_character)	del(loaded_character)
 	var/savefile/S = new /savefile(path)
 	if(!S)					return 0
 	S.cd = "/"
 
 	WRITE_FILE(S["version"], SAVEFILE_VERSION_MAX)
 	player_setup.save_preferences(S)
-	loaded_preferences = S
+	del(S)
 	return 1
 
 /datum/preferences/proc/load_character(slot)
@@ -49,6 +53,8 @@
 	if(!fexists(path))		return 0
 
 	debug_world_log("LOADING CHARACTER FOR [usr]/[usr?.ckey] - PATH: [path]")
+	if(loaded_preferences)	del(loaded_preferences)
+	if(loaded_character)	del(loaded_character)
 	var/savefile/S = new /savefile(path)
 	if(!S)					return 0
 	S.cd = "/"
@@ -80,23 +86,25 @@
 			to_chat(client, span_warning("You're attempting to save your character a little too fast. Wait half a second, then try again."))
 		return 0
 	debug_world_log("SAVING CHARACTER FOR [usr]/[usr?.ckey] - PATH: [path]")
+	if(loaded_preferences)	del(loaded_preferences)
+	if(loaded_character)	del(loaded_character)
 	var/savefile/S = new /savefile(path)
 	if(!S)					return 0
 	S.cd = GLOB.maps_data.character_save_path(default_slot)
 
 	S["version"] << SAVEFILE_VERSION_MAX
 	player_setup.save_character(S)
-	loaded_character = S
-	return S
+	del(S)
+	return 1
 
 /datum/preferences/proc/sanitize_preferences()
 	player_setup.sanitize_setup()
 	return 1
 
-/datum/preferences/proc/update_setup(savefile/preferences, savefile/character)
-	if(!preferences || !character)
+/datum/preferences/proc/update_setup(pref_version, savefile/character)
+	if(!character)
 		return 0
-	return player_setup.update_setup(preferences, character)
+	return player_setup.update_setup(pref_version, character)
 
 #undef SAVEFILE_VERSION_MAX
 #undef SAVEFILE_VERSION_MIN

--- a/code/modules/multiz/map_data.dm
+++ b/code/modules/multiz/map_data.dm
@@ -162,10 +162,12 @@ GLOBAL_DATUM_INIT(maps_data, /datum/maps_data, new)
 	S.cd = original_cd // Attempting to make this call as side-effect free as possible
 
 /datum/maps_data/proc/private_use_legacy_saves(savefile/S, slot)
-	if(!S.dir.Find(path)) // If we cannot find the map path folder, load the legacy save
-		return TRUE
-	S.cd = "/[path]" // Finally, if we cannot find the character slot in the map path folder, load the legacy save
-	return !S.dir.Find("character[slot]")
+	// Directly read the version key at the path
+	// If no version is found, the slot has no version data, fall back to legacy
+	S.cd = "/[path]/character[slot]"
+	var/new_version
+	S["version"] >> new_version
+	return !new_version
 
 
 /datum/maps_data/proc/registrate(obj/map_data/MD)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR attempts to fix character preferences/setup on both Linux and Windows.
This code should clear all handles to files preventing file lock state on Linux.
Additionaly, slots were not correctly loaded due to bug with determining which character prefs version is used, in which case system always attempted to load old prefs, despite new being available.

This PR additionally fixes skin tone issue. Skin tone after change in character setup UI wasn't properly displayed if not save explicitly to slot and reloaded.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

If those changes work, they should fix issue with no player prefs being saved/loaded on live server.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Those changes would require not-so extensive testing, but at least sanity checkup on live server, before actual launch, to avoid potential issues or data corruption.

My local tests went good, slots are saved, pesistent across multiple instance launches, skin tone changes after changing in UI, no lock state happening (though I'm testing it on Windows, so it might not be the same for live server working on Linux)
<img width="952" height="750" alt="image" src="https://github.com/user-attachments/assets/127e240c-7dd8-4087-a0ec-64f5cb5c39ff" />


<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
fix: character preferences not saving due to file lock
fix: character prefs not loading
fix: skin tone not changing in character setup menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
