### PR TITLE
fix: admin traitor panel unable to remove traitor status (#222)

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -106,6 +106,11 @@
 /datum/mind/proc/store_memory(new_text)
 	memory += "[new_text]<BR>"
 
+/datum/mind/proc/remove_memory(text)
+	var/pos = findtext(memory, text)
+	if(pos)
+		memory = copytext(memory, 1, pos) + copytext(memory, pos + length(text))
+
 /datum/mind/proc/print_individualobjectives()
 	var/output
 	if(LAZYLEN(individual_objectives))
@@ -158,8 +163,10 @@
 		out += "<a href='byond://?src=\ref[src];add_antagonist=[antag.bantype]'>[antag_name]</a><br>"
 	out += "<br>"
 
+	var/antag_index = 1
 	for(var/datum/antagonist/antag in antagonist)
-		out += "<br><b>[antag.role_text]</b> <a href='byond://?src=\ref[antag]'>\[EDIT\]</a> <a href='byond://?src=\ref[antag];remove_antagonist=1'>\[DEL\]</a>"
+		out += "<br><b>[antag.role_text] #[antag_index]</b> <a href='byond://?src=\ref[antag]'>\[EDIT\]</a> <a href='byond://?src=\ref[antag];remove_antagonist=1'>\[DEL\]</a>"
+		antag_index++
 	out += "</table><hr>"
 	out += "<br>[memory]"
 
@@ -175,6 +182,12 @@
 	if(href_list["add_antagonist"])
 		var/datum/antagonist/antag = GLOB.all_antag_types[href_list["add_antagonist"]]
 		if(antag)
+			for(var/datum/antagonist/existing in antagonist)
+				if(istype(existing, antag.type))
+					var/dup_answer = alert("[name] already has the [antag.role_text] role. Add another one anyway?", "Duplicate Role Warning", "No", "Yes")
+					if(dup_answer != "Yes")
+						return
+					break
 			var/ok = FALSE
 			if(antag.outer && active)
 				var/answer = alert("[antag.role_text] is an outer antagonist. [name] will be taken from the current mob and spawned as antagonist. Continue?","Confirmation", "No","Yes")
@@ -186,18 +199,20 @@
 			if(!ok)
 				return
 
+			var/datum/antagonist/new_antag = new antag.type
 			if(antag.outer)
 				//Outer antags are created from ghosts, we must make a ghost first
 				var/mob/observer/ghost/ghost = current.ghostize(FALSE)
-				antag.create_from_ghost(ghost, announce = FALSE)
+				new_antag.create_from_ghost(ghost, announce = FALSE)
 				qdel(current) //Delete our old body
-				antag.greet()
+				new_antag.greet()
 
 			else
-				if(antag.create_antagonist(src))
-					log_admin("[key_name_admin(usr)] made [key_name(src)] into a [antag.role_text].")
+				if(new_antag.create_antagonist(src))
+					log_admin("[key_name_admin(usr)] made [key_name(src)] into a [new_antag.role_text].")
 				else
-					to_chat(usr, span_warning("[src] could not be made into a [antag.role_text]!"))
+					to_chat(usr, span_warning("[src] could not be made into a [new_antag.role_text]!"))
+					qdel(new_antag)
 
 	else if(href_list["role_edit"])
 		var/new_role = input("Select new role", "Assigned role", assigned_role) as null|anything in GLOB.joblist

--- a/code/datums/uplink/uplink_sources.dm
+++ b/code/datums/uplink/uplink_sources.dm
@@ -35,6 +35,7 @@ GLOBAL_LIST_INIT(default_uplink_source_priority, list(
 	P.hard_drive.store_file(program)
 	to_chat(M, span_notice("A portable object teleportation relay has been installed in your [P.name]. Simply enter the code \"[pda_pass]\" in your new program to unlock its hidden features."))
 	M.mind.store_memory("<B>Uplink passcode:</B> [pda_pass] ([P.name]).")
+	T.memory_entry = "<B>Uplink passcode:</B> [pda_pass] ([P.name]).<BR>"
 
 /decl/uplink_source/radio
 	name = "Radio"
@@ -60,6 +61,7 @@ GLOBAL_LIST_INIT(default_uplink_source_priority, list(
 	T.trigger_code = freq
 	to_chat(M, span_notice("A portable object teleportation relay has been installed in your [R.name]. Simply dial the frequency [format_frequency(freq)] to unlock its hidden features."))
 	M.mind.store_memory("<B>Radio Freq:</B> [format_frequency(freq)] ([R.name]).")
+	T.memory_entry = "<B>Radio Freq:</B> [format_frequency(freq)] ([R.name]).<BR>"
 
 /decl/uplink_source/implant
 	name = "Implant"

--- a/code/game/antagonist/antagonist_create.dm
+++ b/code/game/antagonist/antagonist_create.dm
@@ -111,6 +111,10 @@
 	GLOB.current_antags.Remove(src)
 	if (!owner)
 		return //This can happen with some spamclicking
+	if(owner.current && ishuman(owner.current) && length(stat_modifiers))
+		var/mob/living/L = owner.current
+		for(var/name in stat_modifiers)
+			L.stats.changeStat(name, -stat_modifiers[name])
 	if(owner.current)
 		BITSET(owner.current.hud_updateflag, SPECIALROLE_HUD)
 

--- a/code/game/antagonist/antagonist_equip.dm
+++ b/code/game/antagonist/antagonist_equip.dm
@@ -75,5 +75,9 @@
 	return R
 
 /datum/antagonist/proc/spawn_uplink(mob/living/carbon/human/contractor_mob, amount = DEFAULT_TELECRYSTAL_AMOUNT)
+	var/list/before = GLOB.world_uplinks.Copy()
 	setup_uplink_source(contractor_mob, amount)
+	for(var/obj/item/device/uplink/U in GLOB.world_uplinks)
+		if(!(U in before))
+			U.source_antag = src
 

--- a/code/game/antagonist/antagonist_panel.dm
+++ b/code/game/antagonist/antagonist_panel.dm
@@ -79,7 +79,11 @@
 					create_from_ghost(M)
 
 	else if(href_list["remove_antagonist"])
+		var/datum/mind/prev_owner = owner
 		remove_antagonist()
+		if(prev_owner)
+			prev_owner.edit_memory()
+		return
 
 	else if(href_list["equip_antagonist"])
 		equip()

--- a/code/game/antagonist/station/contractor.dm
+++ b/code/game/antagonist/station/contractor.dm
@@ -51,8 +51,6 @@
 /datum/antagonist/contractor/remove_antagonist()
 	if(owner && owner.current && ishuman(owner.current))
 		var/mob/living/L = owner.current
-		for(var/name in stat_modifiers)
-			L.stats.changeStat(name, -stat_modifiers[name])
 		for(var/obj/item/device/uplink/U in GLOB.world_uplinks.Copy())
 			if(U.source_antag == src)
 				if(U.memory_entry)

--- a/code/game/antagonist/station/contractor.dm
+++ b/code/game/antagonist/station/contractor.dm
@@ -48,6 +48,21 @@
 	return TRUE
 
 
+/datum/antagonist/contractor/remove_antagonist()
+	if(owner && owner.current && ishuman(owner.current))
+		var/mob/living/L = owner.current
+		for(var/name in stat_modifiers)
+			L.stats.changeStat(name, -stat_modifiers[name])
+		for(var/obj/item/device/uplink/U in GLOB.world_uplinks.Copy())
+			if(U.source_antag == src)
+				if(U.memory_entry)
+					owner.remove_memory(U.memory_entry)
+				qdel(U)
+		owner.remove_memory("<b>Code Phrase</b>: [syndicate_code_phrase]<BR>")
+		owner.remove_memory("<b>Code Response</b>: [syndicate_code_response]<BR>")
+		to_chat(L, span_warning("Your contract has been terminated. You are no longer an operative."))
+	return ..()
+
 /datum/antagonist/contractor/proc/give_codewords()
 	if(!owner.current)
 		return

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -92,13 +92,6 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 
 
 // The hidden uplink MUST be inside an obj/item's contents.
-/obj/item/device/uplink/hidden/Destroy()
-	if(istype(loc, /obj/item))
-		var/obj/item/parent = loc
-		if(parent.hidden_uplink == src)
-			parent.hidden_uplink = null
-	return ..()
-
 /obj/item/device/uplink/hidden/New(location, datum/mind/owner, telecrystals = DEFAULT_TELECRYSTAL_AMOUNT)
 	spawn(2)
 		if(!istype(src.loc, /obj))
@@ -106,6 +99,13 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 	..()
 	nanoui_data = list()
 	update_nano_data()
+
+/obj/item/device/uplink/hidden/Destroy()
+	if(istype(loc, /obj/item))
+		var/obj/item/parent = loc
+		if(parent.hidden_uplink == src)
+			parent.hidden_uplink = null
+	return ..()
 
 // Toggles the uplink on and off. Normally this will bypass the item's normal functions and go to the uplink menu, if activated.
 /obj/item/device/uplink/hidden/proc/toggle()

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -18,6 +18,8 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 
 	var/list/purchase_log = new
 	var/datum/mind/uplink_owner
+	var/datum/antagonist/source_antag = null // Specific antag datum instance that spawned this uplink
+	var/memory_entry = null // Exact memory string added when this uplink was set up, used for cleanup on removal
 	var/used_TC = 0
 
 	var/list/owner_roles = new
@@ -90,6 +92,13 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 
 
 // The hidden uplink MUST be inside an obj/item's contents.
+/obj/item/device/uplink/hidden/Destroy()
+	if(istype(loc, /obj/item))
+		var/obj/item/parent = loc
+		if(parent.hidden_uplink == src)
+			parent.hidden_uplink = null
+	return ..()
+
 /obj/item/device/uplink/hidden/New(location, datum/mind/owner, telecrystals = DEFAULT_TELECRYSTAL_AMOUNT)
 	spawn(2)
 		if(!istype(src.loc, /obj))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR addresses Traitor panel not refreshing after deletion of traitor status,
It also subtracts stats and clears memories per antag role after traitor status deletion.
Enchanced support for doubled up different and same antags eg. two contractor roles on one person, separate uplinks, separate memories, deletion of memories etc.
Right now deleting one antag shouldn't delete other antag uplinks.
Fixed minor issue when accessing headset frequency of uplink that was deleted.
Added additional dialog warning for admin when adding duplicate antag role for the same person.
Added "Your contract has been terminated. You are no longer an operative." when someones contractor status is removed.

## Why It's Good For The Game

It improves traitor panel and removes some of the bugs that were haunting said place.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Tested it on multiple instances of traitors with doubled up same and different anta roles. 
Seems to be working properly, according memories after role deletion are cleared, uplinks unusable.

Doubled up antags with stat (starting vigilance value = 16)
<img width="1286" height="699" alt="image" src="https://github.com/user-attachments/assets/c7dc1c6c-feef-4eb3-89bc-673a59868a6c" />


Memories and stats after roles removal 
<img width="1246" height="681" alt="image" src="https://github.com/user-attachments/assets/f91a8733-1e9b-4cfe-8411-8f6939bb2503" />



<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
fix: Traitor Panel now properly refreshes after removing an antagonist role
fix: Removing an antagonist role now reverses its stat bonuses
fix: Removing contractor status now deletes the contractor's uplink
fix: Removing contractor status now clears related entries from the player's memory
fix: Removing one contractor role no longer removes uplinks belonging to other contractor roles on the same player
fix: Deleting a headset uplink no longer breaks the headset's frequency selection
admin: Adding a duplicate antagonist role now shows a warning prompt
admin: Multiple antagonist roles of the same type are now numbered in the Traitor Panel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
