### PR TITLE
fix: clicking View on AI law change now teleports ghost and shows laws

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -411,6 +411,13 @@ var/list/ai_verbs_default = list(
 	..()
 
 /mob/living/silicon/ai/Topic(href, href_list)
+	if(href_list["view_laws"] && isobserver(usr))
+		var/mob/observer/ghost/G = usr
+		var/turf/T = get_turf(src)
+		if(T)
+			G.forceMove(T)
+		laws.show_laws(G)
+		return
 	if(usr != src)
 		return
 	if(..())

--- a/code/modules/mob/living/silicon/ai/laws.dm
+++ b/code/modules/mob/living/silicon/ai/laws.dm
@@ -4,9 +4,7 @@
 	src.show_laws()
 
 /mob/living/silicon/proc/deadchat_lawchange()
-	var/list/the_laws = laws.get_law_list(include_zeroth = TRUE)
-	var/lawtext = the_laws.Join("<br/>")
-	deadchat_broadcast("'s <b>laws were changed.</b> <a href='byond://?src=[REF(src)]&dead=1&printlawtext=[url_encode(lawtext)]'>View</a>", span_name("[src]"), follow_target=src, message_type=DEADCHAT_LAWCHANGE)
+	deadchat_broadcast("'s <b>laws were changed.</b> <a href='byond://?src=[REF(src)];dead=1;view_laws=1'>View</a>", span_name("[src]"), follow_target=src, message_type=DEADCHAT_LAWCHANGE)
 
 /mob/living/silicon/ai/show_laws(everyone = 0)
 	var/who


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes "View" link when law is changed on AI. 
It teleports ghost which clicked it to a place where AI is and prints updated AI laws on the console.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Fix good, bug bad

## Testing

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->
On "View" link click, ghost is teleported to AI location and gets its law printed out
<img width="1775" height="513" alt="image" src="https://github.com/user-attachments/assets/2e3963b2-8106-41a3-8b94-5343d6ff90ea" />


## Changelog
:cl:
fix: Clicking "View" on AI law change notification now teleports the ghost to the AI and shows its current laws
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
