### PR TITLE
Improved quality gained from BIO and fix oven

### DIFF
--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -106,7 +106,7 @@
 			ourdrop.name = "[meat.name] [ourdrop.name]"
 			if(istype(ourdrop, /obj/item/reagent_containers/food/snacks))
 				var/obj/item/reagent_containers/food/snacks/ourmeat = ourdrop
-				ourmeat.food_quality = (ourmeat.food_quality * ((bio + 15) / 15) * clamp((toolpowr / 15), 0.25, 4))
+				ourmeat.food_quality = (ourmeat.food_quality * (bio + 15) * clamp(toolpowr, 0.25, 4))
 
 
 	//try to invoke a hazard effect on the butcher

--- a/code/modules/cooking_with_jane/cooking_items/cooking_containers.dm
+++ b/code/modules/cooking_with_jane/cooking_items/cooking_containers.dm
@@ -220,6 +220,7 @@
 /obj/item/reagent_containers/cooking_with_jane/cooking_container/proc/clear_cooking_data()
 	stove_data = list("High"=0 , "Medium" = 0, "Low"=0)
 	grill_data = list("High"=0 , "Medium" = 0, "Low"=0)
+	oven_data = list("High"=0 , "Medium" = 0, "Low"=0)
 
 /obj/item/reagent_containers/cooking_with_jane/cooking_container/proc/label(number, CT = null)
 	//This returns something like "Fryer basket 1 - empty"

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -751,12 +751,14 @@
 			if(has_mob_product)
 				product = new has_mob_product(get_turf(source),name)
 			else
-				var/quality
+				var/quality //product quality
+				var/plantpowr //inherent potency quality before harvest
 				if(force_quality)
 					quality = force_quality
 				else
 					if(livesource && livesource.stats.getStat(STAT_BIO))
-						quality = clamp(1 * ((livesource.stats.getStat(STAT_BIO) + 15) / 15), 0, 10)
+						plantpowr = round(get_trait(TRAIT_POTENCY) / 10)
+						quality = ((livesource.stats.getStat(STAT_BIO) + 15) / 20) * clamp(plantpowr, 0.25, 4)
 					else//nuclear farmbot nerf
 						quality = -5
 				product = new /obj/item/reagent_containers/food/snacks/grown(get_turf(source), name, quality)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. Plants solely relied on BIO, but should also use Plant Potency like how Butchering uses Tool Quality. Rounded things out so that BIO is still the important stat, but better Potency or Tool can help make a difference.

Also fixed the oven tracking, which never cleared it's cooking data between recipes. If it was set to MEDIUM and a recipe was started on it, it would just never clear MEDIUM even if you changed the settings. This resulted in continual bad recipes if you tried to do multiple. Didn't find this in testing because I'm just a little guy and it's my birthday.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Please play club
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Honestly if you think I haven't tested this ad nauseum you have no idea how I do things. I am the worst guy to put behind a keyboard but I will chew my way with brute force and determination.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
tweak: plant and meat quality inheritance
fix: fixed oven cooking data to clear properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
