### PR TITLE
SMALL changes: Excelsior parts progression + Door signalers desc

### DIFF
--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -10,7 +10,6 @@
 /obj/machinery/door/blast
 	name = "Blast Door"
 	desc = "That looks like it doesn't open easily."
-	description_info = "You can use multitool on shutters and blast doors to change codes. If unaccessable, unseal the bolts with welding. \"Remote door signaling device\" can be used to control these."
 	icon = 'icons/obj/doors/rapid_pdoor.dmi'
 
 	var/id = 1

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -10,6 +10,7 @@
 /obj/machinery/door/blast
 	name = "Blast Door"
 	desc = "That looks like it doesn't open easily."
+	description_info = "You can use multitool on shutters and blast doors to change codes. If unaccessable, unseal the bolts with welding. \"Remote door signaling device\" can be used to control these."
 	icon = 'icons/obj/doors/rapid_pdoor.dmi'
 
 	var/id = 1

--- a/code/game/machinery/excelsior/ex_teleporter.dm
+++ b/code/game/machinery/excelsior/ex_teleporter.dm
@@ -90,15 +90,17 @@
 		/obj/item/stack/cable_coil/orange = list("amount" = 30, "price" = 30),
 		)
 	var/list/circuits = list(
+		/obj/item/electronics/circuitboard/excelsior_navigation_cracker = 2000,	//
+		/obj/item/electronics/circuitboard/excelsior_turret = 50,				//
+		/obj/item/electronics/circuitboard/autolathe_disk_cloner = 50,			//
+		/obj/item/electronics/circuitboard/excelsiorreconstructor = 25,			//
+		/obj/item/electronics/circuitboard/excelsior_autodoc = 25,				//
 		/obj/item/electronics/circuitboard/excelsior_teleporter = 10,			//
 		/obj/item/electronics/circuitboard/excelsiorautolathe = 10,				//
-		/obj/item/electronics/circuitboard/excelsior_boombox = 10,				//
 		/obj/item/electronics/circuitboard/diesel = 10,							//
-		/obj/item/electronics/circuitboard/excelsiorreconstructor = 25,			//
 		/obj/item/electronics/circuitboard/excelsiorshieldwallgen = 25,			//
-		/obj/item/electronics/circuitboard/excelsior_autodoc = 25,				//
-		/obj/item/electronics/circuitboard/excelsior_turret = 50,				//
-		/obj/item/electronics/circuitboard/excelsior_navigation_cracker = 2000,	//
+		/obj/item/electronics/circuitboard/excelsior_boombox = 10,				//
+
 		)
 	var/list/excelsior_kits = list(
 		/*		[?]"Factual" means how many energy we woulda spent for 1 material instead of 30. 1:1 cost in other words. [line 48]

--- a/code/game/machinery/excelsior/excelsior_items/KPK.dm
+++ b/code/game/machinery/excelsior/excelsior_items/KPK.dm
@@ -19,7 +19,7 @@
 	var/mode = MODE_NONE
 	var/code_crutch = TRUE	// TODO: DELETE IF STAGE 2 (drone update).
 								//	- This is here cuz no drones yet, but I've decided it might be good to still include it.
-	matter = list(MATERIAL_PLASTIC = 5, MATERIAL_GLASS = 1, MATERIAL_PLASMA = 2)
+	matter = list()	// lets not scrap this by accident
 
 	var/list/active_scanned = list()
 	var/datum/event_source

--- a/code/game/objects/items/weapons/design_disks/excelsior.dm
+++ b/code/game/objects/items/weapons/design_disks/excelsior.dm
@@ -17,6 +17,7 @@
 		/datum/design/autolathe/device/propaganda_chip,
 		/datum/design/autolathe/device/implanter,
 		/datum/design/autolathe/gun/reclaimer,
+
 		/datum/design/research/item/part/basic_capacitor,
 		/datum/design/research/item/part/micro_mani,
 		/datum/design/research/item/part/basic_matter_bin,
@@ -27,16 +28,17 @@
 		/datum/design/research/item/part/subspace_crystal,
 		/datum/design/research/item/part/subspace_transmitter,
 
-		/datum/design/autolathe/part/igniter,						//regular parts
+		/datum/design/autolathe/part/igniter,
 		/datum/design/autolathe/part/signaler,
 		/datum/design/autolathe/part/door_signaler,
 
 		/datum/design/autolathe/part/sensor_prox,
 		/datum/design/autolathe/part/consolescreen,
-		/datum/design/autolathe/cell/large/excelsior,				//power cells
+		//power cells
+		/datum/design/autolathe/cell/large/excelsior,
 		/datum/design/autolathe/cell/medium/excelsior,
 		/datum/design/autolathe/cell/small/excelsior,
-//prostheses
+		//prostheses
 		/datum/design/autolathe/prosthesis/excelsior/l_arm,
 		/datum/design/autolathe/prosthesis/excelsior/r_arm,
 		/datum/design/autolathe/prosthesis/excelsior/l_leg,
@@ -44,8 +46,6 @@
 		/datum/design/autolathe/prosthesis/excelsior/groin,
 		/datum/design/autolathe/prosthesis/excelsior/chest,
 		/datum/design/autolathe/prosthesis/excelsior/head,
-
-		/datum/design/autolathe/container/ammocan_excel
 		// CIRCUITS (commented out)
 		// /datum/design/autolathe/circuit/autolathe_excelsior,
 		// /datum/design/autolathe/circuit/shieldgen_excelsior,

--- a/code/game/objects/items/weapons/design_disks/excelsior.dm
+++ b/code/game/objects/items/weapons/design_disks/excelsior.dm
@@ -1,6 +1,7 @@
 // Excelsior
 /obj/item/computer_hardware/hard_drive/portable/design/excelsior
 	bad_type = /obj/item/computer_hardware/hard_drive/portable/design/excelsior
+	matter = list() // Excelsior can easily softlock themselves to the point the joke stops being funny.
 	origin_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 1)
 	spawn_tags = SPAWN_TAG_DESIGN_EXCELSIOR
 	icon_state = "excelsior"
@@ -13,37 +14,47 @@
 	spawn_blacklisted = TRUE
 	license = -1
 	designs = list(
+		/datum/design/autolathe/device/propaganda_chip,
+		/datum/design/autolathe/device/implanter,
 		/datum/design/autolathe/gun/reclaimer,
-		/datum/design/autolathe/circuit/autolathe_excelsior,		//circuits
-		/datum/design/autolathe/circuit/shieldgen_excelsior,
-		/datum/design/autolathe/circuit/reconstructor_excelsior,
-		/datum/design/autolathe/circuit/diesel_excelsior,
-		/datum/design/autolathe/circuit/excelsior_boombox,
-		/datum/design/autolathe/circuit/turret_excelsior,
-		/datum/design/autolathe/circuit/autolathe_disk_cloner,
 		/datum/design/research/item/part/basic_capacitor,
-		/datum/design/research/item/part/micro_mani,				//machine parts
+		/datum/design/research/item/part/micro_mani,
+		/datum/design/research/item/part/basic_matter_bin,
+		/datum/design/research/item/part/basic_micro_laser,
+		/datum/design/research/item/part/basic_sensor,
+
 		/datum/design/research/item/part/subspace_amplifier,
 		/datum/design/research/item/part/subspace_crystal,
 		/datum/design/research/item/part/subspace_transmitter,
+
 		/datum/design/autolathe/part/igniter,						//regular parts
 		/datum/design/autolathe/part/signaler,
 		/datum/design/autolathe/part/door_signaler,
+
 		/datum/design/autolathe/part/sensor_prox,
 		/datum/design/autolathe/part/consolescreen,
 		/datum/design/autolathe/cell/large/excelsior,				//power cells
 		/datum/design/autolathe/cell/medium/excelsior,
 		/datum/design/autolathe/cell/small/excelsior,
-		/datum/design/autolathe/prosthesis/excelsior/l_arm,         //prostheses
+//prostheses
+		/datum/design/autolathe/prosthesis/excelsior/l_arm,
 		/datum/design/autolathe/prosthesis/excelsior/r_arm,
 		/datum/design/autolathe/prosthesis/excelsior/l_leg,
 		/datum/design/autolathe/prosthesis/excelsior/r_leg,
 		/datum/design/autolathe/prosthesis/excelsior/groin,
 		/datum/design/autolathe/prosthesis/excelsior/chest,
 		/datum/design/autolathe/prosthesis/excelsior/head,
-		/datum/design/autolathe/device/implanter,					//misc
-		/datum/design/autolathe/device/propaganda_chip,
+
 		/datum/design/autolathe/container/ammocan_excel
+		// CIRCUITS (commented out)
+		// /datum/design/autolathe/circuit/autolathe_excelsior,
+		// /datum/design/autolathe/circuit/shieldgen_excelsior,
+		// /datum/design/autolathe/circuit/reconstructor_excelsior,
+		// /datum/design/autolathe/circuit/diesel_excelsior,
+		// /datum/design/autolathe/circuit/excelsior_boombox,
+		// /datum/design/autolathe/circuit/turret_excelsior,
+		// /datum/design/autolathe/circuit/autolathe_disk_cloner,
+		// MISC
 	)
 
 /obj/item/computer_hardware/hard_drive/portable/design/excelsior/weapons

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -4,6 +4,7 @@
 /obj/item/device/assembly/signaler
 	name = "remote signaling device"
 	desc = "Used to remotely activate devices."
+
 	icon_state = "signaller"
 	item_state = "signaler"
 	item_icons = list(
@@ -192,6 +193,8 @@
 /obj/item/device/assembly/signaler/door_controller
 	name = "remote door signaling device"
 	desc = "Used to remotely activate doors. 2 Beeps for opened, 1 for closed, 0 for no answer. Alt-Click to change Mode, Ctrl-Click to change code."
+	description_info = "You can use multitool on shutters and blast doors to change their codes, and you can assemble them yourself too!"
+	description_antag = "For a hack, unseal the doors by welding, then change their codes with multitool."
 	icon_state = "signaller"
 	item_state = "signaler"
 	origin_tech = list(TECH_MAGNET = 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

me tired me make smol stuff :)

- Removed circuits from Excelsior Means of Production disk with game progression in mind
  - Reorganized stuff in disks and teleporter I guesss................... 
  - added disk cloner circuit to teleporter. (No disks though I don't know how to feel about that for now.)
- Added descriptions for remote door signalers and blastdoor/shutters
- Excel Disks and Centor KPK are unsalvagable by autolathe and reclaimer. Uh oh unfun nerd moment!!! 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Excelsior life less overwhelming and less abusey (spoiler it still is overwhelming)
Game is obscure and frustrating. Me don't want that.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Did. No bug...

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:Cat&Deal
:tweak: Made KOMPAK (Excelsior KPK) and Excelsior disks unsalvagable to avoid hardlocks.
:tweak: Reorganized teleporter buy menu, as well as both Excelsior disks.
:del: Removed circuits from Excelsior's Production disk
:spellcheck: Added description explanation to shutters, blast doors, and on "remote door signalling device". (For example, it's in Technomant's Storage and in Excelsior's Production disk)
:add: Added Disk Cloner circuit to Excelsior teleporter.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
