### PR TITLE
Barbed wire fix

### DIFF
--- a/code/game/objects/barricades.dm
+++ b/code/game/objects/barricades.dm
@@ -253,7 +253,7 @@
 	description_info = "Repaired with pliers and dismantled with a wire cutting tool."
 	icon_state = "barbed_wire"
 	block_vehicles = FALSE
-	matter = list(MATERIAL_STEEL = 10)
+	matter = list(MATERIAL_STEEL = 5)
 	var/tresspass_damage = 20 // How much brute is dealt when someone tries to cross or attack the wire
 
 

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -552,7 +552,7 @@
 	jets.trail.set_up(jets)
 
 /obj/item/rig_module/autodoc
-	name = "autodoc module"
+	name = "trial autodoc module"
 	desc = "A complex surgery system for almost all your needs."
 	use_power_cost = 10
 	active = 1
@@ -607,6 +607,7 @@
 	return
 
 /obj/item/rig_module/autodoc/commercial
+	name = "commercial autodoc module"
 	autodoc_type = /datum/autodoc/capitalist_autodoc
 
 /obj/item/rig_module/cape


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

barbed wire takes 5 steel to make so cutting it gives 5 back

## Why It's Good For The Game

no infinite steel exploit

## Testing

<img width="167" height="176" alt="image" src="https://github.com/user-attachments/assets/1a958ecc-5540-467c-8d50-6f080e6c4064" />
<img width="254" height="68" alt="image" src="https://github.com/user-attachments/assets/349000e3-daa9-44ad-9ea9-01e20a4267d6" />

## Changelog
:cl:
tweak: made barbed wire drop 5 instead of 10 steel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
