### PR TITLE
Weapon stock folding QOL

### DIFF
--- a/code/modules/projectiles/guns/projectile/modular.dm
+++ b/code/modules/projectiles/guns/projectile/modular.dm
@@ -251,17 +251,18 @@
 	if(PARTMOD_FOLDING_STOCK & spriteTags)
 		fold()
 
-/obj/item/gun/projectile/modular/proc/quick_fold(mob/user)
-	set name = "Fold or Unfold Stock"
+/obj/item/gun/projectile/modular/proc/quick_fold()
+	set name = "Unique Action"
 	set category = "Object"
 	set src in view(1)
 
-	if(can_interact(user) == 1)
-		return
+	if(usr.incapacitated() || !Adjacent(usr))
+		to_chat(usr, span_warning("You can't do that."))
+		return FALSE
 
-	fold(user)
+	fold(usr)
 
-/obj/item/gun/projectile/modular/proc/fold(user)
+/obj/item/gun/projectile/modular/proc/fold(mob/user)
 
 	if(PARTMOD_FOLDING_STOCK & spriteTags)
 		for(var/obj/item/part/gun/modular/stock/toedit in gun_parts) // only gonna edit one, doing this to find it


### PR DESCRIPTION
## About The Pull Request

Changes the way weapon stocks fold and unfold so it's closer to the Karl mode switch, removing the selection window that would open when other people were nearby and renames the prompt to unique action to make it better compatible with macros.

## Why It's Good For The Game

Makes folding and unfolding stocks with people nearby a lot easier.

## Testing

Tried folding and unfolding a venger stock in an empty room while looking at the stats to make sure it was actually folding. Attempted the same test but with other humans in the room both directly next to me and further away. both tests showed the stock folding and unfolding without opening the selection menu.

## Changelog
:cl:
tweak: changed the stock folding prompt to use unique action instead
code: changed folding code to stop it from opening a selection window when trying to fold/unfold with people nearby
/:cl: