### PR TITLE
Optimize bot pathfinding limits and fix typos

### DIFF
--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -642,7 +642,7 @@
 // calculates a path to the current destination
 // given an optional turf to avoid
 /obj/machinery/bot/mulebot/proc/calc_path(turf/avoid = null)
-	src.path = AStar(src.loc, src.target, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 250, id=botcard, exclude=avoid)
+	src.path = AStar(src.loc, src.target, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 30, id=botcard, exclude=avoid)
 	if(!src.path)
 		src.path = list()
 

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -26,7 +26,7 @@
 	var/blood = 1
 	var/list/target_types = list()
 
-	var/maximum_search_range = 7
+	var/maximum_search_range = 5
 	var/give_up_cooldown = 0
 	var/list/possible_phrases = list(
 		"Foolish organic meatbags can only leak their liquids all over the place.",
@@ -56,7 +56,7 @@
 			return 1
 	if(!path.len)
 //		spawn(0)
-		path = AStar(loc, target.loc, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 30, id = botcard)
+		path = AStar(loc, target.loc, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 5, id = botcard)
 		if(!path)
 			target = null
 			path = list()
@@ -137,14 +137,14 @@
 				var/datum/signal/signal = new()
 				signal.source = src
 				signal.transmission_method = 1
-				signal.data = list("findbeakon" = "patrol")
+				signal.data = list("findbeacon" = "patrol")
 				frequency.post_signal(src, signal, filter = RADIO_NAVBEACONS)
 				signal_sent = world.time
 			else
 				if(next_dest)
 					next_dest_loc = listener.memorized[next_dest]
 					if(next_dest_loc)
-						patrol_path = AStar(loc, next_dest_loc, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 120, id = botcard, exclude = null)
+						patrol_path = AStar(loc, next_dest_loc, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 10, id = botcard, exclude = null)
 						signal_sent = 0
 		else
 			if(pulledby) // Don't wiggle if someone pulls you
@@ -299,7 +299,7 @@
 	var/dist = get_dist(cleanbot, signal.source.loc)
 	memorized[recv] = signal.source.loc
 
-	if(dist < cleanbot.closest_dist) // We check all signals, choosing the closest beakon; then we move to the NEXT one after the closest one
+	if(dist < cleanbot.closest_dist) // We check all signals, choosing the closest beacon; then we move to the NEXT one after the closest one
 		cleanbot.closest_dist = dist
 		cleanbot.next_dest = signal.data["next_patrol"]
 

--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -156,7 +156,7 @@
 					break
 		if(target)
 			var/t = get_dir(target, src) // Turf with the tray is impassable, so a* can't navigate directly to it
-			path = AStar(loc, get_step(target, t), /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 30, id = botcard)
+			path = AStar(loc, get_step(target, t), /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 10, id = botcard)
 			if(!path)
 				path = list()
 

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -173,7 +173,7 @@
 
 	if(target && get_turf(target) != loc && !path.len)
 		spawn(0)
-			path = AStar(loc, get_turf(target), /turf/proc/AdjacentTurfsSpace, /turf/proc/Distance, 0, 30, id = botcard)
+			path = AStar(loc, get_turf(target), /turf/proc/AdjacentTurfsSpace, /turf/proc/Distance, 0, 10, id = botcard)
 			if(!path)
 				path = list()
 				ignorelist += target

--- a/code/modules/mob/living/bot/medbot.dm
+++ b/code/modules/mob/living/bot/medbot.dm
@@ -51,7 +51,7 @@
 					path = list()
 				if(!path.len && (get_dist(src, patient) > 1))
 					spawn(0)
-						path = AStar(loc, get_turf(patient), /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 30, id = botcard)
+						path = AStar(loc, get_turf(patient), /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 10, id = botcard)
 						if(!path)
 							path = list()
 				if(path.len)

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -34,10 +34,10 @@
 	var/list/path = list()
 	var/frustration = 0
 	var/turf/patrol_target = null	// This is where we are headed
-	var/closest_dist				// Used to find the closest beakon
+	var/closest_dist				// Used to find the closest beacon
 	var/destination = "__nearest__"	// This is the current beacon's ID
 	var/next_destination = "__nearest__"	// This is the next beacon's ID
-	var/nearest_beacon				// Tag of the beakon that we assume to be the closest one
+	var/nearest_beacon				// Tag of the beacon that we assume to be the closest one
 
 	var/bot_version = 1.3
 	var/list/threat_found_sounds = new('sound/voice/bcriminal.ogg', 'sound/voice/bjustice.ogg', 'sound/voice/bfreeze.ogg')
@@ -337,7 +337,7 @@
 	return
 
 /mob/living/bot/secbot/proc/calc_path(turf/avoid = null)
-	path = AStar(loc, patrol_target, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 120, id=botcard, exclude=avoid)
+	path = AStar(loc, patrol_target, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 20, id=botcard, exclude=avoid)
 	if(!path)
 		path = list()
 


### PR DESCRIPTION


## About The Pull Request

Reduce AStar distance parameters for all bots to improve pathfinding performance. Cleanbot search range reduced from 7 to 5. Fix beacon/beakon spelling inconsistencies in comments and code. AStar function is unable to use maximum distances over 30 anyways.

## Why It's Good For The Game

Simple changes to the bot pathfinding limits like the roomba. The AStar pathfinding function has a limit that doesn't throw a warning or information flag. Until a more complete rewrite can be done to the algorithm implementation this should help shore up performance issues even slightly.

## Testing

Minor upload error forgot to include testing description.
Testing included A/B testing on a local server.
5 tests of each type were run.
Control
Change made in near round start conditions
Control + mob deletion then spawning of roombas
Change + mob deletion followed by spawning of roombas

The change had minimal impact below 10 roombas but had a measurable 3 ms reduction - this needs additional testing with someone who knows how to set the round init seed
Above 10 roombas there was a difference starting with a decrease of 10ms and maintained gradual lowering.

**Additional Notes**
Outliers in round start testing were discarded and then rerun.
Control had ranges from 180ms to 74ms, was nominally ~110ms
Change had ranges from 178 to 83, was nominally ~107ms


<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
tweak: reduced mulebot, cleanbot, roomba, farmbot, medbot, and secbot pathfinding range.
